### PR TITLE
MainActivity: Execute the pending transitions before switching

### DIFF
--- a/mobile/src/main/java/info/papdt/express/helper/ui/MainActivity.java
+++ b/mobile/src/main/java/info/papdt/express/helper/ui/MainActivity.java
@@ -104,6 +104,7 @@ public class MainActivity extends AbsActivity implements OnMenuTabClickListener 
 
 	@Override
 	public void onMenuTabSelected(@IdRes int menuItemId) {
+		getFragmentManager().executePendingTransactions();
 		FragmentTransaction ft = getFragmentManager().beginTransaction();
 		ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
 		switch (menuItemId) {


### PR DESCRIPTION
This will hopefully fix the crash when swiftly switching between tabs. However, I do not have an Android development environment now, so this is not tested.
